### PR TITLE
Fix #register method of the DSL

### DIFF
--- a/spec/dumb_vm/dsl_spec.rb
+++ b/spec/dumb_vm/dsl_spec.rb
@@ -10,24 +10,44 @@ RSpec.describe DumbVM::DSL do
   let(:instance) { vm_class.new }
 
   describe '#register' do
+    shared_examples 'defining a register called #my_register' do
+      it 'defines an attribute reader for the given register' do
+        expect(instance).to respond_to(:my_register)
+      end
+
+      it 'defines the correct signature for the register' do
+        expect(instance).to have_signature_for(:my_register)
+          .without_params
+          .with_return_type(DumbVM::Register)
+      end
+
+      it 'defines an attribute that creates the register' do
+        expect(instance.my_register).to be_a(DumbVM::Register)
+      end
+
+      it 'defines an attribute that creates the register with the correct size' do
+        expect(instance.my_register).to have_attributes(size: DumbVM::BitLength.bits(8))
+      end
+
+      it 'stores the register on an instance variable' do
+        expect { instance.my_register }
+          .to change { instance.instance_variable_get('@my_register') }.from(nil).to(be_a(DumbVM::Register))
+      end
+    end
+
     context 'when a register is defined' do
       before { vm_class.register :my_register, size: DumbVM::BitLength.bits(8) }
 
-      it 'defines a register with the given size', :aggregate_failures do
-        expect(instance).to respond_to(:my_register)
-        expect(instance.my_register).to be_a(DumbVM::Register)
-        expect(instance.my_register).to have_attributes(size: DumbVM::BitLength.bits(8))
-      end
+      it_behaves_like 'defining a register called #my_register'
     end
 
     context 'when a register is defined with an initial value' do
       before { vm_class.register :my_register, size: DumbVM::BitLength.bits(8), init_value: 15 }
 
-      it 'defines a register with the given size', :aggregate_failures do
-        expect(instance).to respond_to(:my_register)
-        expect(instance.my_register).to be_a(DumbVM::Register)
-        expect(instance.my_register).to have_attributes(size: DumbVM::BitLength.bits(8),
-                                                        value: 15)
+      it_behaves_like 'defining a register called #my_register'
+
+      it 'defines a register with the given default value' do
+        expect(instance.my_register).to have_attributes(value: 15)
       end
     end
   end


### PR DESCRIPTION
The previous definition was missing a `sig` statement and would set the register values on an instance variable at class level, not at instance level